### PR TITLE
use scto_meta to check username and password.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rsurveycto
 Type: Package
 Title: Interact with Data on 'SurveyCTO'
-Version: 0.0.7
+Version: 0.0.8
 Authors@R: c(
   person('Jake', 'Hughey', , 'jakejhughey@gmail.com', c('aut', 'cre')),
   person('Robert', 'On', , 'roberton@gmail.com', 'aut'))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# rsurveycto 0.0.8
+* Added check for valid username and password.
+
 # rsurveycto 0.0.7
 * Added `scto_meta()` function to fetch SurveyCTO metadata.
 

--- a/R/scto_auth.R
+++ b/R/scto_auth.R
@@ -38,7 +38,9 @@ scto_auth = function(
     assert_file_exists(auth_file)
     auth_char = readLines(auth_file, warn = FALSE)
     if (!test_character(auth_char, any.missing = FALSE, len = 3L)) {
-      stop('auth_file must have exactly three lines: servername, username, and password.')}
+      stop(paste(
+        'auth_file must have exactly three lines:',
+        'servername, username, and password.'))}
     servername = auth_char[1L]
     username = auth_char[2L]
     password = auth_char[3L]}
@@ -55,4 +57,6 @@ scto_auth = function(
               csrf_token = session_auth$csrf_token,
               session_id = session_auth$session_id)
   class(auth) = 'scto_auth'
+
+  m = scto_meta(auth) # check for valid username and password
   return(auth)}

--- a/R/scto_read.R
+++ b/R/scto_read.R
@@ -147,10 +147,11 @@ scto_meta = function(auth) {
   url = glue(
     'https://{auth$servername}.surveycto.com/console/forms-groups-datasets/get')
 
-  r = content(
-    GET(url,
-        set_cookies(JSESSIONID = auth$session_id),
-        add_headers('x-csrf-token' = auth$csrf_token)),
-    as = 'parsed')
+  res = GET(url, set_cookies(JSESSIONID = auth$session_id),
+            add_headers('x-csrf-token' = auth$csrf_token))
 
-  return(r)}
+  if (res$status_code != 200L) {
+    stop(glue('Invalid username or password for ',
+              'SurveyCTO server `{auth$servername}`.'))}
+  m = content(res, as = 'parsed')
+  return(m)}

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,7 +11,7 @@ get_session_auth = function(servername, username, password) {
   csrf_token = headers(index_res)$`x-csrf-token`
 
   if (is.null(csrf_token)) {
-    stop(glue('Unable to log in to SurveyCTO server `{servername}`.',
+    stop(glue('Unable to access SurveyCTO server `{servername}`.',
               ' Please check that server is running.'))}
 
   login_url = glue(

--- a/tests/testthat/test-scto-meta.R
+++ b/tests/testthat/test-scto-meta.R
@@ -3,6 +3,11 @@ if (identical(Sys.getenv('NOT_CRAN'), 'true')) { # !on_cran()
 
 test_that('scto_meta ok', {
   skip_on_cran()
-  metadata = scto_meta(auth)
-  expect_type(metadata, 'list')
+  meta = scto_meta(auth)
+
+  nms = c('canAddObjectsIntoRoot', 'groups', 'datasets',
+          'serverDatasetPublishingInfo', 'forms')
+
+  expect_type(meta, 'list')
+  expect_named(meta, nms)
 })


### PR DESCRIPTION
Based on my testing, the value of the user_category cookie is not a reliable indicator of a valid username and password. For example, on the rsurveycto server, an incorrect username will still say "community_user" instead of "anonymous_form_filler". So this code checks credentials by trying to fetch the metadata.